### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ defusedxml==0.7.1
 dill==0.3.5.1
 entrypoints==0.4
 et-xmlfile==1.1.0
-evaluate==0.2.2
+evaluate==0.3.0
 executing==0.9.1
 fastjsonschema==2.16.1
 filelock==3.7.1


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.